### PR TITLE
Fixing event-related warnings from latest truffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ A contract that keeps a registry of metadata of uploaded medical records, as wel
 ## Linnia Permissions
 A contract that keeps a registry of permissions. Permissions include who can view what data, and where the permissioned copy is stored on IPFS.
 
+# Installing (only once)
+
+Installs `babel-register` and `babel-polyfill`.
+
+```
+npm install
+```
+
 # Deploying
 ```
 truffle migrate

--- a/contracts/LinniaHub.sol
+++ b/contracts/LinniaHub.sol
@@ -26,7 +26,7 @@ contract LinniaHub is Ownable {
     {
         address prev = address(rolesContract);
         rolesContract = _rolesContract;
-        LogRolesContractSet(prev, _rolesContract);
+        emit LogRolesContractSet(prev, _rolesContract);
         return true;
     }
 
@@ -37,7 +37,7 @@ contract LinniaHub is Ownable {
     {
         address prev = address(recordsContract);
         recordsContract = _recordsContract;
-        LogRecordsContractSet(prev, _recordsContract);
+        emit LogRecordsContractSet(prev, _recordsContract);
         return true;
     }
 
@@ -48,7 +48,7 @@ contract LinniaHub is Ownable {
     {
         address prev = address(permissionsContract);
         permissionsContract = _permissionsContract;
-        LogPermissionsContractSet(prev, _permissionsContract);
+        emit LogPermissionsContractSet(prev, _permissionsContract);
         return true;
     }
 }

--- a/contracts/LinniaPermissions.sol
+++ b/contracts/LinniaPermissions.sol
@@ -54,7 +54,7 @@ contract LinniaPermissions is Ownable {
             canAccess: true,
             ipfsHash: ipfsHash
         });
-        LogAccessGranted(msg.sender, viewer, fileHash);
+        emit LogAccessGranted(msg.sender, viewer, fileHash);
         return true;
     }
 
@@ -74,7 +74,7 @@ contract LinniaPermissions is Ownable {
             canAccess: false,
             ipfsHash: 0
         });
-        LogAccessRevoked(msg.sender, viewer, fileHash);
+        emit LogAccessRevoked(msg.sender, viewer, fileHash);
         return true;
     }
 }

--- a/contracts/LinniaRecords.sol
+++ b/contracts/LinniaRecords.sol
@@ -180,7 +180,7 @@ contract LinniaRecords is Ownable {
         // add the reverse mapping
         ipfsRecords[ipfsHash] = fileHash;
         // emit event
-        LogRecordAdded(fileHash, patient);
+        emit LogRecordAdded(fileHash, patient);
         return true;
     }
 
@@ -202,7 +202,7 @@ contract LinniaRecords is Ownable {
         // update iris score
         record.irisScore = record.irisScore.add(provenanceScore);
         // emit event
-        LogRecordSigAdded(fileHash, provider, record.irisScore);
+        emit LogRecordSigAdded(fileHash, provider, record.irisScore);
         return true;
     }
 }

--- a/contracts/LinniaRoles.sol
+++ b/contracts/LinniaRoles.sol
@@ -41,7 +41,7 @@ contract LinniaRoles is Ownable {
             exists: true,
             registerBlocktime: block.number
         });
-        LogPatientRegistered(msg.sender);
+        emit LogPatientRegistered(msg.sender);
         return true;
     }
 
@@ -53,7 +53,7 @@ contract LinniaRoles is Ownable {
             // providers start with 1 provenance score for now
             provenance: 1
         });
-        LogProviderRegistered(user);
+        emit LogProviderRegistered(user);
         return true;
     }
 
@@ -64,7 +64,7 @@ contract LinniaRoles is Ownable {
             exists: false,
             provenance: 0
         });
-        LogProviderRemoved(user);
+        emit LogProviderRemoved(user);
         return true;
     }
 


### PR DESCRIPTION
Fixes warning: Invoking events without "emit" prefix is deprecated

- Reported in #20 