### PR TITLE
Add pause test for every pasuable function

### DIFF
--- a/contracts/LinniaRecords.sol
+++ b/contracts/LinniaRecords.sol
@@ -68,7 +68,6 @@ contract LinniaRecords is Ownable, Pausable {
         bytes32 dataHash, address owner, address attestator,
         string metadata, string dataUri)
         onlyOwner
-        whenNotPaused
         external
         returns (bool)
     {
@@ -88,7 +87,6 @@ contract LinniaRecords is Ownable, Pausable {
     function addRecord(
         bytes32 dataHash, string metadata, string dataUri)
         onlyUser
-        whenNotPaused
         public
         returns (bool)
     {
@@ -107,7 +105,6 @@ contract LinniaRecords is Ownable, Pausable {
         bytes32 dataHash, address owner, string metadata, string dataUri)
         onlyUser
         hasProvenance(msg.sender)
-        whenNotPaused
         public
         returns (bool)
     {
@@ -124,7 +121,6 @@ contract LinniaRecords is Ownable, Pausable {
     /// @param dataHash the data hash of the linnia record
     function addSigByProvider(bytes32 dataHash)
         hasProvenance(msg.sender)
-        whenNotPaused
         public
         returns (bool)
     {
@@ -144,7 +140,6 @@ contract LinniaRecords is Ownable, Pausable {
     /// @param v signature: V
     function addSig(bytes32 dataHash, bytes32 r, bytes32 s, uint8 v)
         public
-        whenNotPaused
         returns (bool)
     {
         // find the root hash of the record
@@ -186,6 +181,7 @@ contract LinniaRecords is Ownable, Pausable {
 
     function _addRecord(
         bytes32 dataHash, address owner, string metadata, string dataUri)
+        whenNotPaused
         internal
         returns (bool)
     {
@@ -215,6 +211,7 @@ contract LinniaRecords is Ownable, Pausable {
 
     function _addSig(bytes32 dataHash, address provider)
         hasProvenance(provider)
+        whenNotPaused
         internal
         returns (bool)
     {

--- a/contracts/LinniaRecords.sol
+++ b/contracts/LinniaRecords.sol
@@ -68,6 +68,7 @@ contract LinniaRecords is Ownable, Pausable {
         bytes32 dataHash, address owner, address attestator,
         string metadata, string dataUri)
         onlyOwner
+        whenNotPaused
         external
         returns (bool)
     {
@@ -87,6 +88,7 @@ contract LinniaRecords is Ownable, Pausable {
     function addRecord(
         bytes32 dataHash, string metadata, string dataUri)
         onlyUser
+        whenNotPaused
         public
         returns (bool)
     {
@@ -105,6 +107,7 @@ contract LinniaRecords is Ownable, Pausable {
         bytes32 dataHash, address owner, string metadata, string dataUri)
         onlyUser
         hasProvenance(msg.sender)
+        whenNotPaused
         public
         returns (bool)
     {
@@ -122,6 +125,7 @@ contract LinniaRecords is Ownable, Pausable {
     function addSigByProvider(bytes32 dataHash)
         hasProvenance(msg.sender)
         public
+        whenNotPaused
         returns (bool)
     {
         require(_addSig(dataHash, msg.sender));
@@ -140,6 +144,7 @@ contract LinniaRecords is Ownable, Pausable {
     /// @param v signature: V
     function addSig(bytes32 dataHash, bytes32 r, bytes32 s, uint8 v)
         public
+        whenNotPaused
         returns (bool)
     {
         // find the root hash of the record
@@ -181,7 +186,6 @@ contract LinniaRecords is Ownable, Pausable {
 
     function _addRecord(
         bytes32 dataHash, address owner, string metadata, string dataUri)
-        whenNotPaused
         internal
         returns (bool)
     {
@@ -211,7 +215,6 @@ contract LinniaRecords is Ownable, Pausable {
 
     function _addSig(bytes32 dataHash, address provider)
         hasProvenance(provider)
-        whenNotPaused
         internal
         returns (bool)
     {

--- a/contracts/LinniaRecords.sol
+++ b/contracts/LinniaRecords.sol
@@ -124,8 +124,8 @@ contract LinniaRecords is Ownable, Pausable {
     /// @param dataHash the data hash of the linnia record
     function addSigByProvider(bytes32 dataHash)
         hasProvenance(msg.sender)
-        public
         whenNotPaused
+        public
         returns (bool)
     {
         require(_addSig(dataHash, msg.sender));
@@ -143,8 +143,8 @@ contract LinniaRecords is Ownable, Pausable {
     /// @param s signature: S
     /// @param v signature: V
     function addSig(bytes32 dataHash, bytes32 r, bytes32 s, uint8 v)
-        public
         whenNotPaused
+        public
         returns (bool)
     {
         // find the root hash of the record

--- a/test/2_users_test.js
+++ b/test/2_users_test.js
@@ -57,6 +57,10 @@ contract("LinniaUsers", (accounts) => {
           instance.register({ from: accounts[1] })
         )
       })
+    it("should not allow user to register when paused", async () => {
+      await instance.pause({ from: accounts[0] })
+      await assertRevert(instance.register({ from: accounts[1] }))
+    })
   })
   describe("set provenance", () => {
     it("should allow admin to set provenance of a user", async () => {
@@ -103,20 +107,18 @@ contract("LinniaUsers", (accounts) => {
       assert.equal(await instance.provenanceOf(accounts[1]), 0)
     })
   })
-  describe("pausable", () => {
-    it("should not allow non-admin to pause or unpause", async () => {
+  describe("pause and unpause", () => {
+    it("should not allow non admin to pause or unpause", async () => {
       await assertRevert(instance.pause({ from: accounts[1] }))
       await assertRevert(instance.unpause({ from: accounts[1] }))
     })
-    it("should not allow register of users when paused by admin", async () => {
-      const tx = await instance.pause()
-      assert.equal(await instance.isUser(accounts[1]), false)
+    it("should allow admin to pause and unpause", async () => {
+      const tx = await instance.pause({ from: accounts[0] })
       assert.equal(tx.logs[0].event, "Pause")
-      await assertRevert(instance.register({ from: accounts[1] }))
-      const tx2 = await instance.unpause()
+      assert.isTrue(await instance.paused())
+      const tx2 = await instance.unpause({ from: accounts[0] })
       assert.equal(tx2.logs[0].event, "Unpause")
-      const tx3 = await instance.register({ from: accounts[1] })
-      assert.equal(tx3.logs[0].event, "LogUserRegistered")
+      assert.isFalse(await instance.paused())
     })
   })
 })


### PR DESCRIPTION
- no records can be added or attested when records contract is paused
- whenNotPaused tests moved to affected methods in tests