### PR TITLE
make IPFS hashes bs58 in tests

### DIFF
--- a/test/3_records_test.js
+++ b/test/3_records_test.js
@@ -11,10 +11,7 @@ import assertRevert from "openzeppelin-solidity/test/helpers/assertRevert"
 
 const testDataContent = `{"foo":"bar","baz":42}`
 const testDataHash = eutil.bufferToHex(eutil.sha3(testDataContent))
-const testDataUri = eutil.bufferToHex(
-  multihashes.decode(
-    bs58.decode(
-      "QmUMqi1rr4Ad1eZ3ctsRUEmqK2U3CyZqpetUe51LB9GiAM")).digest)
+const testDataUri = "QmUMqi1rr4Ad1eZ3ctsRUEmqK2U3CyZqpetUe51LB9GiAM"
 const testMetadata = "KEYWORDS"
 const testMetaHash = eutil.bufferToHex(eutil.sha3(testMetadata))
 const testRootHash = eutil.bufferToHex(eutil.sha3(Buffer.concat([

--- a/test/4_permissions_test.js
+++ b/test/4_permissions_test.js
@@ -14,12 +14,8 @@ const testDataContent1 = `{"foo":"bar","baz":42}`
 const testDataContent2 = `{"asdf":42}`
 const testDataHash1 = eutil.bufferToHex(eutil.sha3(testDataContent1))
 const testDataHash2 = eutil.bufferToHex(eutil.sha3(testDataContent2))
-const testDataUri1 = eutil.bufferToHex(
-  multihashes.decode(
-    bs58.decode("QmUMqi1rr4Ad1eZ3ctsRUEmqK2U3CyZqpetUe51LB9GiAM")).digest)
-const testDataUri2 = eutil.bufferToHex(
-  multihashes.decode(
-    bs58.decode("QmUoCHEZqSuYhr9fV1c2b4gLASG2hPpC2moQXQ6qzy697d")).digest)
+const testDataUri1 = "QmUMqi1rr4Ad1eZ3ctsRUEmqK2U3CyZqpetUe51LB9GiAM"
+const testDataUri2 = "QmUoCHEZqSuYhr9fV1c2b4gLASG2hPpC2moQXQ6qzy697d"
 const testMetadata = "KEYWORDS"
 
 contract("LinniaPermissions", (accounts) => {


### PR DESCRIPTION
From hex encoded sha2-256 to just bs58 encoded multihash like the ones used in ipfs