### PR TITLE
feat/policiesForRecords

### DIFF
--- a/contracts/LinniaHub.sol
+++ b/contracts/LinniaHub.sol
@@ -6,15 +6,18 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./LinniaUsers.sol";
 import "./LinniaRecords.sol";
 import "./LinniaPermissions.sol";
+import "./LinniaPolicies.sol";
 
 
 contract LinniaHub is Ownable, Destructible {
     LinniaUsers public usersContract;
     LinniaRecords public recordsContract;
+    LinniaPolicies public policiesContract;
     LinniaPermissions public permissionsContract;
 
     event LinniaUsersContractSet(address from, address to);
     event LinniaRecordsContractSet(address from, address to);
+    event LinniaPoliciesContractSet(address from, address to);
     event LinniaPermissionsContractSet(address from, address to);
 
     constructor() public { }
@@ -40,6 +43,17 @@ contract LinniaHub is Ownable, Destructible {
         address prev = address(recordsContract);
         recordsContract = _recordsContract;
         emit LinniaRecordsContractSet(prev, _recordsContract);
+        return true;
+    }
+
+    function setPoliciesContract(LinniaPolicies _policiesContract)
+        onlyOwner
+        external
+        returns (bool)
+    {
+        address prev = address(policiesContract);
+        policiesContract = _policiesContract;
+        emit LinniaPoliciesContractSet(prev, _policiesContract);
         return true;
     }
 

--- a/contracts/LinniaPolicies.sol
+++ b/contracts/LinniaPolicies.sol
@@ -1,0 +1,176 @@
+pragma solidity 0.4.24;
+
+import "openzeppelin-solidity/contracts/lifecycle/Destructible.sol";
+import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
+
+import "./LinniaHub.sol";
+
+import "./interfaces/PolicyI.sol";
+
+/**
+
+    This contract acts as a container for all policy related logic in Stow protocol.
+
+    A policy is a smart contract that looks at the state of a record or a permission
+    and validates whether certain logic is true. Policies are used when creating records
+    and granting access to records to make sure that certain contraints are being met.
+    Users can choose to add and remove constraints their own records. App creators can
+    also choose to conform to policies while faciliating the permissioning of their user's
+    files.
+
+**/
+
+contract LinniaPolicies is Pausable, Destructible {
+
+    /* @dev dataHash of record => policies for the record */
+    mapping(bytes32 => address[]) public recordPolicies;
+
+    LinniaHub public hub;
+
+    event LinniaPolicyChecked(
+        bytes32 indexed dataHash,
+        string dataUri,
+        address indexed viewer,
+        address indexed policy,
+        bool isOk,
+        address sender
+    );
+
+    /* Constructor */
+    constructor(LinniaHub _hub) public {
+        hub = _hub;
+    }
+
+    /* Fallback function */
+    function () public { }
+
+    modifier onlyRecordOwnerOf(bytes32 dataHash) {
+        require(hub.recordsContract().recordOwnerOf(dataHash) == msg.sender);
+        _;
+    }
+
+    modifier onlyUser() {
+        require(hub.usersContract().isUser(msg.sender) == true);
+        _;
+    }
+
+    /* @dex checks an array of policies to make sure they are valid */
+    /* @param dataHash the dataHash of the record being checked */
+    /* @param viewer the address of the person being given access the record */
+    /* @param dataUri where the record is */
+    /* @param policies an array of the policy conforming addresses */
+    function policiesAreValid(
+        bytes32 dataHash,
+        address viewer,
+        string dataUri,
+        address[] policies)
+        public
+        returns (bool)
+    {
+        /* @dev check policies and fail on first one that is not ok */
+        for (uint i = 0; i < policies.length; i++) {
+            address curPolicy = policies[i];
+            require(policyIsValid(dataHash, viewer, dataUri, curPolicy));
+        }
+
+        return true;
+    }
+
+    /* @dev checks if a new permission follows existing record policies */
+    /* @param dataHash the dataHash of the record being checked */
+    /* @param viewer the address of the person being given access the record */
+    /* @param dataUri where the record is */
+    function followsExistingPolicies(
+        bytes32 dataHash,
+        address viewer,
+        string dataUri)
+        public
+        returns (bool)
+    {
+        return policiesAreValid(
+            dataHash,
+            viewer,
+            dataUri,
+            recordPolicies[dataHash]
+        );
+    }
+
+    function policiesForRecord(bytes32 dataHash) view returns (address[]) {
+        return recordPolicies[dataHash];
+    }
+
+    /* @dev checks an array of policies to make sure they are valid */
+    /* @param dataHash the dataHash of the record being checked */
+    /* @param viewer the address of the person being given access the record */
+    /* @param dataUri where the record is */
+    /* @param policies an array of the policy conforming addresses */
+    function policyIsValid(
+        bytes32 dataHash,
+        address viewer,
+        string dataUri,
+        address policy)
+        public
+        returns (bool)
+    {
+        require(policy != address(0));
+        PolicyI currPolicy = PolicyI(policy);
+        bool isOk = currPolicy.checkPolicy(dataHash, viewer, dataUri);
+        emit LinniaPolicyChecked(dataHash, dataUri, viewer, policy, isOk, msg.sender);
+        require(isOk);
+        return true;
+    }
+
+    /* @dev allows a record owner to add a policy to a record as long as it conforms */
+    /* @param dataHash the record the owner is adding a policy to */
+    /* @param policy an address of a contract that conforms to the policy interface to add */
+    function addPolicyToRecord(bytes32 dataHash, address policy)
+        whenNotPaused
+        external
+        returns (bool)
+    {
+        /* @dev get the dataUri and the owner address from the records contract */
+        (address owner, , , , string memory dataUri, ) = hub.recordsContract().records(dataHash);
+
+        /* @dev only the owner of the record or the contract itself */
+        require(msg.sender == address(hub.recordsContract()) || msg.sender == owner);
+
+        /* @dev original record must be policy complaint to work */
+        require(policyIsValid(
+            dataHash,
+            msg.sender,
+            dataUri,
+            policy
+        ));
+
+        recordPolicies[dataHash].push(policy);
+
+        return true;
+    }
+
+    /* @dev allows an owner to remove a policy from a record */
+    /* @param dataHash the dataHash of the record being policied */
+    /* @param policy the address of the policy to remove */
+    function removePolicyFromRecord(bytes32 dataHash, address policy)
+        onlyUser
+        onlyRecordOwnerOf(dataHash)
+        whenNotPaused
+        external
+        returns (bool)
+    {
+        /* @dev search through the policies for the record */
+        for (uint i = 0; i < recordPolicies[dataHash].length; i++) {
+            /* @dev if one is found */
+            if (recordPolicies[dataHash][i] == policy) {
+                /* @dev remove the policy by shifting everything over and shortening array */
+                while (i < recordPolicies[dataHash].length - 1) {
+                    recordPolicies[dataHash][i] = recordPolicies[dataHash][i + 1];
+                    i++;
+                }
+
+                recordPolicies[dataHash].length--;
+            }
+        }
+
+        return true;
+    }
+}

--- a/contracts/interfaces/PolicyI.sol
+++ b/contracts/interfaces/PolicyI.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 
-contract /* interface */ PermissionPolicyI {
+contract /* interface */ PolicyI {
 
     /// check permission policy then return true if condition are met
     /// @param viewer the user being granted permission to view the data

--- a/contracts/mock/PolicyMock.sol
+++ b/contracts/mock/PolicyMock.sol
@@ -1,9 +1,9 @@
 pragma solidity 0.4.24;
 
-import "../interfaces/PermissionPolicyI.sol";
+import "../interfaces/PolicyI.sol";
 
 
-contract /* interface */ PermissionPolicyMock is PermissionPolicyI {
+contract /* interface */ PolicyMock is PolicyI {
 
     bool public result = true;
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,30 +1,36 @@
-const LinniaHub = artifacts.require("./LinniaHub.sol")
-const LinniaUsers = artifacts.require("./LinniaUsers.sol")
-const LinniaRecords = artifacts.require("./LinniaRecords.sol")
-const LinniaPermissions = artifacts.require("./LinniaPermissions.sol")
+const LinniaHub = artifacts.require("./LinniaHub.sol");
+const LinniaUsers = artifacts.require("./LinniaUsers.sol");
+const LinniaRecords = artifacts.require("./LinniaRecords.sol");
+const LinniaPolicies = artifacts.require("./LinniaPolicies.sol");
+const LinniaPermissions = artifacts.require("./LinniaPermissions.sol");
 
 module.exports = (deployer, network, accounts) => {
-  const adminAddress = accounts[0]
-  let hubInstance
+  const adminAddress = accounts[0];
+  let hubInstance;
   // deploy the hub
   deployer.deploy(LinniaHub).then(() => {
-    return LinniaHub.deployed()
+    return LinniaHub.deployed();
   }).then((_hubInstace) => {
-    hubInstance = _hubInstace
+    hubInstance = _hubInstace;
     // deploy Users
-    return deployer.deploy(LinniaUsers, hubInstance.address)
+    return deployer.deploy(LinniaUsers, hubInstance.address);
   }).then(() => {
     // deploy Records
-    return deployer.deploy(LinniaRecords, hubInstance.address)
+    return deployer.deploy(LinniaRecords, hubInstance.address);
+  }).then(() => {
+    // deploy Policies
+    return deployer.deploy(LinniaPolicies, hubInstance.address);
   }).then(() => {
     // deploy Permissions
-    return deployer.deploy(LinniaPermissions, hubInstance.address)
+    return deployer.deploy(LinniaPermissions, hubInstance.address);
   }).then(() => {
     // set all the addresses in the hub
-    return hubInstance.setUsersContract(LinniaUsers.address)
+    return hubInstance.setUsersContract(LinniaUsers.address);
   }).then(() => {
-    return hubInstance.setRecordsContract(LinniaRecords.address)
+    return hubInstance.setRecordsContract(LinniaRecords.address);
   }).then(() => {
-    return hubInstance.setPermissionsContract(LinniaPermissions.address)
+    return hubInstance.setPoliciesContract(LinniaPolicies.address);
+  }).then(() => {
+    return hubInstance.setPermissionsContract(LinniaPermissions.address);
   })
 }

--- a/test/7_policies_tests.js
+++ b/test/7_policies_tests.js
@@ -1,0 +1,142 @@
+import assertRevert from 'openzeppelin-solidity/test/helpers/assertRevert';
+import eutil from 'ethereumjs-util';
+
+const LinniaHub = artifacts.require('./LinniaHub.sol');
+const LinniaUsers = artifacts.require('./LinniaUsers');
+const LinniaRecords = artifacts.require('./LinniaRecords.sol');
+const LinniaPolicies = artifacts.require('./LinniaPolicies.sol');
+const Policy = artifacts.require('./mock/PolicyMock.sol');
+
+const testDataContent = '{"foo":"bar","baz":42}';
+const testDataHash = eutil.bufferToHex(eutil.sha3(testDataContent));
+const testDataUri = 'QmUMqi1rr4Ad1eZ3ctsRUEmqK2U3CyZqpetUe51LB9GiAM';
+const testMetadata = 'KEYWORDS';
+
+contract('LinniaPolicies', accounts => {
+  let hub;
+  let records;
+  let policies;
+  let policy;
+
+  before('set up a LinniaHub contract', async () => {
+    hub = await LinniaHub.new();
+    records = await LinniaRecords.new(hub.address);
+    await hub.setRecordsContract(records.address);
+  });
+
+  before('set up users contract and registers user', async () => {
+    const users = await LinniaUsers.new(hub.address);
+    await hub.setUsersContract(users.address);
+    await users.register();
+  });
+
+  before('add a record', async () => {
+    await records.addRecord(testDataHash, testMetadata, testDataUri, { from: accounts[0] });
+  });
+
+  beforeEach('new policies contract', async () => {
+    policies = await LinniaPolicies.new(hub.address);
+    await hub.setPoliciesContract(policies.address);
+  });
+
+  beforeEach('deploy a new polic', async () => {
+    policy = await Policy.new();
+  });
+
+  describe('followsExistingPolicies', () => {
+    it('should return true if new permission conforms to record policies', async () => {
+      await policies.addPolicyToRecord(testDataHash, policy.address);
+      const doesConform = await policies.followsExistingPolicies(
+        testDataHash,
+        accounts[0],
+        testDataUri
+      );
+      assert(doesConform);
+    });
+    it('should revert if it doesnt follow existing policies', async () => {
+      await policies.addPolicyToRecord(testDataHash, policy.address);
+      await policy.setVal(false);
+      assertRevert(policies.followsExistingPolicies(
+        testDataHash,
+        accounts[0],
+        testDataUri
+      ));
+    });
+  });
+  describe('policiesAreValid', () => {
+    it('should return true is policy is valid', async () => {
+      assert(await policies.policyIsValid(
+        testDataHash,
+        accounts[0],
+        testDataUri,
+        [policy.address]
+      ));
+    });
+    it('should revert if not conforming', async () => {
+      await policy.setVal(false);
+      assertRevert(policies.policyIsValid(
+        testDataHash,
+        accounts[0],
+        testDataUri,
+        [policy.address]
+      ));
+    });
+  });
+  describe('policyIsValid', () => {
+    it('should return true is policy is valid', async () => {
+      assert(await policies.policyIsValid(
+        testDataHash,
+        accounts[0],
+        testDataUri,
+        policy.address
+      ));
+    });
+    it('should emit an event saying that the record/permission is valid', async () => {
+      const tx = await policies.policyIsValid(
+        testDataHash,
+        accounts[0],
+        testDataUri,
+        policy.address
+      );
+
+      assert.equal(tx.logs[0].event, 'LinniaPolicyChecked');
+    });
+    it('should revert if not conforming', async () => {
+      await policy.setVal(false);
+      assertRevert(policies.policyIsValid(
+        testDataHash,
+        accounts[0],
+        testDataUri,
+        policy.address
+      ));
+    });
+  });
+  describe('addPolicyToRecord', () => {
+    it('should allow a user to add a policy to her record', async () => {
+      await policies.addPolicyToRecord(testDataHash, policy.address);
+      const recordPolicies = await policies.policiesForRecord(testDataHash);
+      assert.equal(policy.address, recordPolicies[0]);
+    });
+    it('should not allow a user to add a policy to someone elses record', async () => {
+      assertRevert(policies.addPolicyToRecord(testDataHash, policy.address, { from: accounts[2] }));
+    });
+    it('should not let a user add a non conforming policy to record', async () => {
+      await policy.setVal(false);
+      assertRevert(policies.addPolicyToRecord(testDataHash, policy.address));
+      const recordPolicies = await policies.policiesForRecord(testDataHash);
+      assert.equal(recordPolicies.length, 0);
+    });
+  });
+  describe('removePolicyFromRecord', () => {
+    it('should remove a policy from a record you own', async () => {
+      await policies.addPolicyToRecord(testDataHash, policy.address);
+      await policies.removePolicyFromRecord(testDataHash, policy.address);
+      const recordPolicies = await policies.policiesForRecord(testDataHash);
+      assert.equal(recordPolicies.length, 0);
+    });
+    it('should not let a non owner remove a policy', async () => {
+      await policies.addPolicyToRecord(testDataHash, policy.address);
+      assertRevert(policies.addPolicyToRecord(testDataHash, policy.address, { from: accounts[1] }));
+    });
+  });
+});


### PR DESCRIPTION
Implements policy constrained record appending and persistent record based policies.

Users now have the option to check against policies when appending data. These policies are stored, and again checked when user grants access for file to new users.

Also allows users to add and remove policies for their records.